### PR TITLE
change the date to the testopolis seed project to 05.06.2024

### DIFF
--- a/publication/README.md
+++ b/publication/README.md
@@ -42,7 +42,8 @@ iex -S mix phx.server
 
 Now you can visit [`localhost:4001`](http://localhost:4001) in your browser and should see the landing page. The next step would be to login as the COUCHDB_USER as defined in the [docker-compose.yml](docker-compose.yml). 
 
-## 3. Seed Project for Development
+
+## 4. Seed Project for Development
 By running
 
 ```

--- a/publication/README.md
+++ b/publication/README.md
@@ -41,3 +41,12 @@ iex -S mix phx.server
 ```
 
 Now you can visit [`localhost:4001`](http://localhost:4001) in your browser and should see the landing page. The next step would be to login as the COUCHDB_USER as defined in the [docker-compose.yml](docker-compose.yml). 
+
+## 3. Seed Project for Development
+By running
+
+```
+mix seed
+```
+
+you can add a local copy of 'testopolis' as a finished publication for testing during development.

--- a/publication/lib/field_publication/database_schema/replication_input.ex
+++ b/publication/lib/field_publication/database_schema/replication_input.ex
@@ -12,6 +12,7 @@ defmodule FieldPublication.DatabaseSchema.ReplicationInput do
     field(:project_name, :string)
     field(:delete_existing_publication, :boolean, default: false)
     field(:processing, :boolean, default: true)
+    field(:draft_date, :date, default: Date.utc_today())
   end
 
   @doc false
@@ -19,6 +20,7 @@ defmodule FieldPublication.DatabaseSchema.ReplicationInput do
     input_struct
     |> cast(attrs, [
       :drafted_by,
+      :draft_date,
       :source_url,
       :source_project_name,
       :source_user,

--- a/publication/lib/field_publication/publications.ex
+++ b/publication/lib/field_publication/publications.ex
@@ -19,9 +19,9 @@ defmodule FieldPublication.Publications do
         source_project_name: source_project_name,
         project_name: project_name,
         delete_existing_publication: delete_existing,
-        drafted_by: drafted_by
+        drafted_by: drafted_by,
+        draft_date: draft_date
       }) do
-    draft_date = Date.utc_today()
 
     changeset =
       %Publication{

--- a/publication/test/support/fixtures/seed_project/project_seed.ex
+++ b/publication/test/support/fixtures/seed_project/project_seed.ex
@@ -99,7 +99,6 @@ defmodule FieldPublication.Test.ProjectSeed do
 
     {:ok, %FieldPublication.DatabaseSchema.Publication{} = publication} =
       Publications.put(publication, %{
-        "publication_date" => Date.from_iso8601!("2024-06-05"),
         "comments" => [
           %{
             "text" =>

--- a/publication/test/support/fixtures/seed_project/project_seed.ex
+++ b/publication/test/support/fixtures/seed_project/project_seed.ex
@@ -53,7 +53,8 @@ defmodule FieldPublication.Test.ProjectSeed do
         "source_user" => "local_developer",
         "source_password" => "fake",
         "project_name" => identifier,
-        "drafted_by" => "mix seed"
+        "drafted_by" => "mix seed",
+        "draft_date" => Date.from_iso8601!("2024-06-05")
       })
 
     {:ok, %Publication{} = publication} =
@@ -98,7 +99,7 @@ defmodule FieldPublication.Test.ProjectSeed do
 
     {:ok, %FieldPublication.DatabaseSchema.Publication{} = publication} =
       Publications.put(publication, %{
-        "publication_date" => Date.utc_today(),
+        "publication_date" => Date.from_iso8601!("2024-06-05"),
         "comments" => [
           %{
             "text" =>

--- a/publication/test/support/fixtures/seed_project/project_seed.ex
+++ b/publication/test/support/fixtures/seed_project/project_seed.ex
@@ -99,6 +99,7 @@ defmodule FieldPublication.Test.ProjectSeed do
 
     {:ok, %FieldPublication.DatabaseSchema.Publication{} = publication} =
       Publications.put(publication, %{
+        "publication_date" => Date.from_iso8601!("2024-06-05"),
         "comments" => [
           %{
             "text" =>


### PR DESCRIPTION
The choice of date is rather random and manually assigned in the seed-script; in this case it is the last change in the project database. We wanted to change the date to something that in the past so that one could draft a new publication from the testopolis project on Field Hub on the same day as running `mix seed` to get the (local) test project.