### PR TITLE
Support arbitrary file sizes in FieldHub

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,8 +12,8 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.13.0-erlang-24.2-debian-bullseye-20210902-slim
 #
-ARG BUILDER_IMAGE="hexpm/elixir:1.13.0-erlang-24.2-debian-bullseye-20210902-slim"
-ARG RUNNER_IMAGE="debian:bullseye-20210902-slim"
+ARG BUILDER_IMAGE="hexpm/elixir:1.18.3-erlang-25.3.2.20-debian-bookworm-20250407-slim"
+ARG RUNNER_IMAGE="debian:bookworm-20250407-slim"
 
 FROM ${BUILDER_IMAGE} as builder
 

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -31,7 +31,6 @@ config :field_hub,
   couchdb_user_password: "app_user_password",
   valid_file_variants: [:thumbnail_image, :original_image],
   file_index_cache_name: :file_info,
-  file_max_size: 1_000_000_000,
   user_tokens_cache_name: :user_tokens,
   max_project_identifier_length: 30
 

--- a/server/config/test.exs
+++ b/server/config/test.exs
@@ -23,6 +23,4 @@ config :logger, :console, level: :error
 config :phoenix, :plug_init_mode, :runtime
 
 config :field_hub,
-  file_directory_root: "test/tmp",
-  # ~10mb instead of the 1gb default value
-  file_max_size: 10_000_000
+  file_directory_root: "test/tmp"

--- a/server/lib/field_hub/file_store.ex
+++ b/server/lib/field_hub/file_store.ex
@@ -180,6 +180,26 @@ defmodule FieldHub.FileStore do
   end
 
   @doc """
+  Open a io_device for a new file.
+
+  The io_device can then be used to write chunked/streamed data without having to
+  load the whole file into memory at once.
+
+  __Parameters__
+
+  - `uuid` the uuid for the file (will be used as its file_name).
+  - `project_identifier` the project's name.
+  - `file_variant` a valid file variant, one of `#{inspect(@valid_file_variants)}`.
+
+  Returns `{:ok, io_device}` on success or `{:error, posix}` on failure.
+  """
+  def create_write_io_device(uuid, project_identifier, file_variant) do
+    directory = get_variant_directory(project_identifier, file_variant)
+    file_path = "#{directory}/#{uuid}"
+    File.open(file_path, [:write])
+  end
+
+  @doc """
   Mark all file variants for a UUID/file as deleted.
 
   The function will add an empty tombstone file for the given UUID in all its existing variants. The FileStore

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -4,7 +4,7 @@ defmodule FieldHub.MixProject do
   def project do
     [
       app: :field_hub,
-      version: "3.3.2",
+      version: "3.4.0",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),

--- a/server/test/field_hub_web/controllers/api/file_controller_test.exs
+++ b/server/test/field_hub_web/controllers/api/file_controller_test.exs
@@ -59,17 +59,17 @@ defmodule FieldHubWeb.Api.Rest.FileTest do
     assert conn.status == 400
   end
 
-  test "PUT /files/:project/:uuid with file exceeding maximum size throws 413", %{conn: conn} do
-    roughly_20_mb = String.duplicate("0123456789", 2_000_000)
+  # test "PUT /files/:project/:uuid with file exceeding maximum size throws 413", %{conn: conn} do
+  #   roughly_20_mb = String.duplicate("0123456789", 2_000_000)
 
-    conn =
-      conn
-      |> put_req_header("authorization", @basic_auth)
-      |> put_req_header("content-type", "image/png")
-      |> put("/files/#{@project}/1234?type=original_image", roughly_20_mb)
+  #   conn =
+  #     conn
+  #     |> put_req_header("authorization", @basic_auth)
+  #     |> put_req_header("content-type", "image/png")
+  #     |> put("/files/#{@project}/1234?type=original_image", roughly_20_mb)
 
-    assert conn.status == 413
-  end
+  #   assert conn.status == 413
+  # end
 
   test "GET /files/:project/:uuid returns 404 for non-existent file", %{conn: conn} do
     credentials = Base.encode64("#{@user_name}:#{@user_password}")


### PR DESCRIPTION
Arbitrary to the extent, that the server has enough disk space...

Currently uploaded files are still capped at 1gb size and loaded into memory before saving.
